### PR TITLE
minor changes needed for Vivado synthesis

### DIFF
--- a/rtl/mem/ddram.sv
+++ b/rtl/mem/ddram.sv
@@ -60,7 +60,7 @@ module ddram
 	output reg[63:0] cpdout,
 	output reg       cpwr,
 	input            cpreq,
-	output           cpbusy
+	output reg       cpbusy
 );
 
 assign DDRAM_BURSTCNT = ram_burst;

--- a/rtl/mem/sdram_2w_cl2.sv
+++ b/rtl/mem/sdram_2w_cl2.sv
@@ -134,7 +134,7 @@ localparam RFRSH_CYCLES = 16'd78*MHZ/4'd10;
  SDRAM state machine for 2 bank interleaved access
  2 word burst, CL2
 cmd issued  registered
- 0 RAS0     data1 retruned
+ 0 RAS0     data1 returned
  1          ras0 - data1 returned
  2 CAS0
  3 RAS1

--- a/rtl/video_sync/irq.v
+++ b/rtl/video_sync/irq.v
@@ -37,7 +37,9 @@ module irq_sync(
 	assign ACK[1] = ~&{nWR_ACK, ACK_BITS[1]};
 	assign ACK[2] = ~&{nWR_ACK, ACK_BITS[2]};
 	
-	wire B56_Q, B56_nQ = ~B56_Q, B52_Q, B52_nQ = ~B52_Q, C52_Q;
+	wire B56_Q, B52_Q, C52_Q;
+	wire B56_nQ = ~B56_Q;
+	wire B52_nQ = ~B52_Q;
 	//FD3 B56(RESET_IRQ, 1'b0, ACK[0], B56_Q, B56_nQ);
 	//FD3 B52(TIMER_IRQ, 1'b0, ACK[1], B52_Q, B52_nQ);
 	//FD3 C52(VBL_IRQ, 1'b0, ACK[2], C52_Q);

--- a/rtl/video_sync/lspc2_a2.v
+++ b/rtl/video_sync/lspc2_a2.v
@@ -192,7 +192,8 @@ module lspc2_a2_sync(
 	wire U72_OUT = ONE_PIXEL ^ nEVEN_ODD;
 	wire U57B_OUT = nPARITY_INIT & U72_OUT;
 	wire U56A_OUT = ~|{S58A_OUT, U57B_OUT};
-	wire CLK_24MB, LSPC_12M, U68A_nQ = ~CK_HSHRINK_REG;
+	wire CLK_24MB, LSPC_12M;
+	wire U68A_nQ = ~CK_HSHRINK_REG;
 	reg  CK_HSHRINK_REG, EVEN_nODD, nEVEN_ODD;
 //	FD2 U68A(CLK_24MB, ~LSPC_12M, CK_HSHRINK_REG, /*U68A_nQ*/);
 //	FD2 U74A(~U68A_nQ, U56A_OUT, EVEN_nODD, nEVEN_ODD);
@@ -531,7 +532,8 @@ module lspc2_a2_sync(
 	assign CHG = CHG_r;
 	
 	// SS1/2 outputs, periodic
-	wire nFLIP, nCHG_D = ~CHG_D, R15_QD;
+	wire nFLIP, R15_QD;
+	wire nCHG_D = ~CHG_D;
 	reg S48_nQ;
 	
 	// Latch nFLIP at pixel 264 (O62_Q). That will make the line buffers switch at pixel 267.


### PR DESCRIPTION
those are the changes need for Vivado synthesis (at least prior to neogeo cd commits)

irq.v and lspc2_a2.v  have different line endings.  I tried different editors in Linux but all endup screwing up the changes view. Actually there are only a few changes, and you can see them clearly  hiding whitespace in config from changes view.